### PR TITLE
Fix: ログイン前でも投稿ページに遷移できるよう仮修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,5 @@
 class PostsController < ApplicationController
+  skip_before_action :require_login
   
   def index
     @posts = Post.published.order(created_at: :desc)
@@ -65,10 +66,6 @@ class PostsController < ApplicationController
     post = Post.find(params[:id])
     post.destroy
     redirect_to posts_path, notice: "削除しました。"
-  end
-
-  def example
-    
   end
 
   private

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -10,8 +10,8 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav ms-auto mb-2 mb-lg-0">
+          <li><%= link_to "投稿一覧", posts_path, class: "nav-link text-white active" %></li>
           <% if logged_in? %>
-            <li><%= link_to "投稿一覧", posts_path, class: "nav-link text-white active" %></li>
             <li><%= link_to "録音する", new_post_path, class: "nav-link text-white" %></li>
             <li><%= link_to "プロフィール編集",  posts_path, class: "nav-link text-white" %></li>
             <%# edit_user_path(current_user.id) %>


### PR DESCRIPTION
- postコントローラーで:require_loginをスキップ
- ヘッダーのビューにて、投稿一覧リンクを常に表示