### PR TITLE
Feature fix post and user #40

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -53,7 +53,8 @@ class PostsController < ApplicationController
     @post = Post.new(
       title: post_params[:title],
       body: post_params[:body],
-      status: post_params[:status]
+      status: post_params[:status],
+      user_id: current_user.id
     )
     
     # Blob IDから録音データを取得

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -18,12 +18,14 @@ class PostsController < ApplicationController
     @post = Post.find(params[:id])
     
     # 元音源のデータ取得
-    if @post.collab_src
-      @collab_post = Post.find_by(id: @post.collab_src)
+    if @post.collab_src.present?
+      # @collab_post = Post.find_by(id: @post.collab_src)
+      @collab_post = @post.base_post
     end
     # 大元音源のデータ取得
     if @collab_post.present? && @collab_post.collab_src
-      @root_collab_post = Post.find(@collab_post.collab_src)
+      # @root_collab_post = Post.find(@collab_post.collab_src)
+      @root_collab_post = @collab_post.base_post
     end
   end
 
@@ -41,10 +43,9 @@ class PostsController < ApplicationController
     
     # クエリパラメータで取得した投稿データのさらに紐づいた投稿データを確認し取得
     if @collab_post.present? && @collab_post.collab_src #左から実行。present?で値の有無を確認し、エラーを防ぐ
-      @root_collab_post = Post.find(@collab_post.collab_src)
+      # @root_collab_post = Post.find(@collab_post.collab_src)
+      @root_collab_post = @collab_post.base_post
     end
-
-
   end
 
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,11 @@
 class Post < ApplicationRecord
   has_one_attached :voice
+  
+  # 投稿とコラボ投稿の関連（自己結合）
+  # コラボ元投稿から、コラボ投稿群を参照
+  has_many :collab_posts, class_name: "Post", foreign_key: "collab_src"
+  # コラボ投稿から、元となる投稿を参照
+  belongs_to :base_post, class_name: "Post", optional: true, foreign_key: "collab_src"
 
   validates :title, presence: true, on: :update
   validates :body, length: { maximum: 100 }

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,10 +1,10 @@
 class Post < ApplicationRecord
   has_one_attached :voice
-  
+  belongs_to :user
   # 投稿とコラボ投稿の関連（自己結合）
-  # コラボ元投稿から、コラボ投稿群を参照
+  ## コラボ元投稿から、コラボ投稿群を参照
   has_many :collab_posts, class_name: "Post", foreign_key: "collab_src"
-  # コラボ投稿から、元となる投稿を参照
+  ## コラボ投稿から、元となる投稿を参照
   belongs_to :base_post, class_name: "Post", optional: true, foreign_key: "collab_src"
 
   validates :title, presence: true, on: :update

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
+  has_many :posts
   mount_uploader :avatar, AvatarUploader
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -20,7 +20,7 @@
             <% else %>
               <p><%= "【投稿】" %></p>
             <% end %>
-            <p><%= post.id %></p>
+            <p><%= post.user.name %></p>
 
 
             <div class="card-body">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -34,7 +34,7 @@
         <%# 自身のみ表示 %>
         <p class="card-text"><%= "#{@post.status}" %></p>
 
-        <p class="card-text"><%= "ユーザー名: #{}" %></p>
+        <p class="card-text"><%= "ユーザー名: #{@post.user.name}" %></p>
         
         
         <p class="card-text"><%= "ID: #{@post.id}" %></p>

--- a/db/migrate/20230726005334_add_user_to_posts.rb
+++ b/db/migrate/20230726005334_add_user_to_posts.rb
@@ -1,0 +1,5 @@
+class AddUserToPosts < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :posts, :user, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_05_15_122600) do
+ActiveRecord::Schema.define(version: 2023_07_26_005334) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -30,10 +30,10 @@ ActiveRecord::Schema.define(version: 2023_05_15_122600) do
     t.string "filename", null: false
     t.string "content_type"
     t.text "metadata"
+    t.string "service_name", null: false
     t.bigint "byte_size", null: false
     t.string "checksum", null: false
     t.datetime "created_at", null: false
-    t.string "service_name", null: false
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
@@ -51,6 +51,8 @@ ActiveRecord::Schema.define(version: 2023_05_15_122600) do
     t.datetime "updated_at", precision: 6, null: false
     t.integer "status", default: 0, null: false
     t.string "ext_type"
+    t.bigint "user_id", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
   create_table "recordings", force: :cascade do |t|
@@ -71,4 +73,5 @@ ActiveRecord::Schema.define(version: 2023_05_15_122600) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "posts", "users"
 end


### PR DESCRIPTION
ユーザーと投稿に対する関連付け
- postsテーブルに外部キー（user_id）を追加
- postsモデルのuser_idに自身のユーザーidが追加されるようにposts/createアクションを修正
- 投稿一覧・詳細にユーザー名を表示