### PR TITLE
Feature fix compile

### DIFF
--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -2,6 +2,8 @@
 # exit on error
 set -o errexit
 
+export NODE_OPTIONS=--openssl-legacy-provider
+
 bundle install
 RAILS_ENV=production bundle exec rails db:migrate
 RAILS_ENV=production bundle exec rails assets:clean

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,3 +1,27 @@
 const { environment } = require('@rails/webpacker')
+const MiniCssExtractPlugin = require('mini-css-extract-plugin')
+
+// 環境に応じてローダーを切り替える
+const styleLoader = process.env.RAILS_ENV === 'production' ? MiniCssExtractPlugin.loader : 'style-loader';
+
+environment.loaders.append('sass', {
+  test: /\.scss$/,
+  use: [
+    styleLoader, // 開発時は 'style-loader', 本番時は MiniCssExtractPlugin.loader
+    'css-loader',
+    'sass-loader'
+  ]
+})
+
+
+// 本番環境の場合のみプラグインを追加
+if (process.env.RAILS_ENV === 'production') {
+  environment.plugins.append(
+    'MiniCssExtract',
+    new MiniCssExtractPlugin({
+      filename: '[name]-[contenthash].css'
+    })
+  )
+}
 
 module.exports = environment


### PR DESCRIPTION
### Node関連のエラー
Node17以降の仕様によりOpenSSLの設定が変更したことにより発生するエラーとのこと
`Error: error:0308010C:digital envelope routines::unsupported`

### 対応

- 環境変数を設定


### ローダーの重複によるエラー
```
ERROR in ./app/javascript/stylesheets/application.scss
Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
ModuleBuildError: Module build failed (from ./node_modules/postcss-loader/src/index.js):
```

### 対応

- ローダーの設定を追加
