### PR TITLE
Fix: 本番環境エラー/ダブルクォーテーションに変更

### DIFF
--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -21,7 +21,7 @@ class AvatarUploader < CarrierWave::Uploader::Base
   #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
   # end
   def default_url
-    'flamenco_icon.jpeg'
+    "flamenco_icon.jpeg"
   end
 
   # Process files as they are uploaded:


### PR DESCRIPTION
render/本番環境エラー対応
`ActionView::Template::Error (The asset "flamenco_icon.jpeg" is not present in the asset pipeline.`

内容
アップローダー設定の表記を修正